### PR TITLE
Robotmap cleanup

### DIFF
--- a/src/main/java/frc/team4533/robot/RobotMap.java
+++ b/src/main/java/frc/team4533/robot/RobotMap.java
@@ -18,15 +18,15 @@ public class RobotMap {
 	public static int X_BUTTON = 1;
 
 	// Drive System Mappings
-	public static int MOTOR_LEFT_MASTER = 3;
+	public static int MOTOR_LEFT_MASTER = 0;
 	public static int MOTOR_LEFT_SLAVE = 1;
-	public static int MOTOR_RIGHT_MASTER = 4;
-	public static int MOTOR_RIGHT_SLAVE = 5;
+	public static int MOTOR_RIGHT_MASTER = 2;
+	public static int MOTOR_RIGHT_SLAVE = 3;
 
 	// Intake System Mappings
-	public static int INTAKE_RIGHT = 99;
-	public static int INTAKE_LEFT = 99;
+	public static int INTAKE_LEFT = 5;
+	public static int INTAKE_RIGHT = 6;
 
 	// Swing Arm System Mappings
-	public static int SWING_ARM_MOTOR = 99;
+	public static int SWING_ARM_MOTOR = 4;
 }

--- a/src/main/java/frc/team4533/robot/RobotMap.java
+++ b/src/main/java/frc/team4533/robot/RobotMap.java
@@ -1,11 +1,9 @@
 package frc.team4533.robot;
 
 public class RobotMap {
+
+	// Controller Mappings
 	public static int JOYSTICK_PORT = 0;
-	public static int MOTOR_RIGHT_MASTER = 4; //These are placeholder values for the motors
-	public static int MOTOR_LEFT_MASTER = 3;
-	public static int MOTOR_RIGHT_SLAVE = 5;
-	public static int MOTOR_LEFT_SLAVE = 1;
 	public static int RIGHT_STICK_BUTTON = 12;
 	public static int LEFT_STICK_BUTTON = 11;
 	public static int START_BUTTON = 10;
@@ -18,4 +16,17 @@ public class RobotMap {
 	public static int B_BUTTON = 3;
 	public static int A_BUTTON = 2;
 	public static int X_BUTTON = 1;
+
+	// Drive System Mappings
+	public static int MOTOR_LEFT_MASTER = 3;
+	public static int MOTOR_LEFT_SLAVE = 1;
+	public static int MOTOR_RIGHT_MASTER = 4;
+	public static int MOTOR_RIGHT_SLAVE = 5;
+
+	// Intake System Mappings
+	public static int INTAKE_RIGHT = 99;
+	public static int INTAKE_LEFT = 99;
+
+	// Swing Arm System Mappings
+	public static int SWING_ARM_MOTOR = 99;
 }


### PR DESCRIPTION
Simply cleans up `RobotMap.java`, organizing how the constants are laid out. As well, it adds the official CAN Bus addresses for the Drive, Intake and Swing Arm Subsystems.